### PR TITLE
パーツ表示を微調整・イベントリスナー二重登録の修正

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -11,6 +11,6 @@
 }
 
 /* パーツサムネイル用: 中のベクターパスの塗りを #888 に統一する */
-.svg-part-thumb * {
-  fill: #888888 !important;
+.svg-part-thumb [style*="fill:#"]:not([style*="fill:none"]):not([style*="fill: none"]) {
+  fill: #BBCCDD !important;
 }


### PR DESCRIPTION
・SVG をベクターイメージとして読み込むよう変更。
・編集画面にパーツを投入する際、元データ（SVGファイル）の塗り色を変換する処理の調整。
・コントローラ内部処理の調整。