### PR TITLE
Posts一覧にページネーション（Kaminari）導入

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -15,8 +15,13 @@ class PostsController < ApplicationController
   before_action :set_blueprint, only: %i[edit update]
 
   def index
-    # 公開投稿のみ（新しい順）
-    @posts = Post.published.order(created_at: :desc)
+    # 公開投稿のみ + 新しい順 + 安定ソート
+    @posts =
+      Post.published
+        .with_attached_image
+        .order(created_at: :desc, id: :desc)
+        .page(params[:page])
+        .per(20)
   end
 
   def show

--- a/app/views/posts/_pager.html.slim
+++ b/app/views/posts/_pager.html.slim
@@ -1,0 +1,5 @@
+- return unless collection.respond_to?(:total_pages)
+- return if collection.total_pages <= 1
+
+.mt-6.flex.justify-center
+  = paginate collection

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -4,6 +4,8 @@
   .container.mx-auto.px-4.py-8
     h1.text-2xl.font-bold.mb-4 投稿一覧
 
+    = render "pager", collection: @posts
+
     - if @posts.present?
       / カードのグリッドレイアウト
       .grid.grid-cols-1.md:grid-cols-3.lg:grid-cols-5.gap-6
@@ -13,7 +15,7 @@
               / ▼ サムネイル
               div class="relative w-full bg-slate-100 overflow-hidden"
                 - if post.image.attached?
-                  = image_tag post.image, class: "w-full h-auto block"
+                  = image_tag post.image.variant(resize_to_limit: [800, 800]), class: "w-full h-auto block"
                 - else
                   = image_tag "no_image.png", class: "w-full h-auto block opacity-70"
 
@@ -30,6 +32,8 @@
                   = l post.created_at, format: :short
     - else
       p.text-slate-500 投稿がまだありません。
+
+    = render "pager", collection: @posts
 
     - if user_signed_in?
       .mt-6

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 20
+  # config.max_per_page = nil
+  config.window = 2
+  config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,32 +1,106 @@
-# テストユーザーを作成（既にいればそれを使う）
-user = User.find_by(email: "test@example.com")
+# db/seeds.rb
+require "tempfile"
+require "base64"
 
-unless user
-  user = User.create!(
-    name: "テストユーザー",
-    email: "test@example.com",
-    password: "password",
-    password_confirmation: "password"
-  )
-  puts "Test user created: #{user.email}"
-else
-  puts "Test user already exists: #{user.email}"
+DESIRED_POSTS = 45
+TEST_EMAIL = "test@example.com"
+
+# 1x1 PNG (透明) fallback
+PNG_1X1_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6X8n9kAAAAASUVORK5CYII="
+
+def build_png_tempfile(label:)
+  tmp = Tempfile.new([ "seed-post-", ".png" ])
+  tmp.binmode
+
+  # MiniMagick が使えるなら、少し大きめの画像を生成（一覧で見やすい）
+  begin
+    require "mini_magick"
+
+    MiniMagick::Tool::Convert.new do |convert|
+      convert.size "800x600"
+      convert.xc "#f1f5f9"            # slate-100 相当の背景
+      convert.gravity "center"
+      convert.pointsize "42"
+      convert.fill "#0f172a"          # slate-900 相当
+      convert.draw "text 0,0 '#{label}'"
+      convert << tmp.path
+    end
+  rescue LoadError, StandardError
+    # 画像生成に失敗しても seeds が落ちないよう、最小PNGで代替
+    tmp.write(Base64.decode64(PNG_1X1_BASE64))
+  end
+
+  tmp.rewind
+  tmp
 end
 
-# テスト投稿を複数作成
-if Post.count == 0
-  3.times do |i|
-    Post.create!(
+# テストユーザー（既存ならそれを使用）
+user = User.find_or_create_by!(email: TEST_EMAIL) do |u|
+  u.name = "テストユーザー"
+  u.password = "password"
+  u.password_confirmation = "password"
+end
+puts "Test user: #{user.email} (id=#{user.id})"
+
+current_count = Post.published.count
+to_create = [ DESIRED_POSTS - current_count, 0 ].max
+
+if to_create.zero?
+  puts "Published posts already exist (#{current_count}). Skip creating posts."
+  exit
+end
+
+# Blueprint が preview_image を持つか（環境差で落とさない）
+blueprint_has_preview_image =
+  Blueprint.respond_to?(:reflect_on_attachment) &&
+  Blueprint.reflect_on_attachment(:preview_image).present?
+
+puts "Creating #{to_create} published posts (current published: #{current_count} / desired: #{DESIRED_POSTS})..."
+puts "Blueprint preview_image attach: #{blueprint_has_preview_image ? 'enabled' : 'skipped'}"
+
+to_create.times do |n|
+  i = current_count + n + 1
+
+  post = nil
+  blueprint = nil
+
+  # 1) まず DB だけ作る（ここでは添付しない）
+  ActiveRecord::Base.transaction do
+    post = Post.create!(
       user: user,
-      title: "テスト投稿 #{i + 1}",
-      caption: <<~CAPTION,
-        これはテスト投稿 #{i + 1} です。
-        動作確認用のダミーキャプションです。
-      CAPTION
-      is_published: true
+      title: "テスト投稿 #{i}",
+      caption: "これはテスト投稿 #{i} です。ページネーション表示確認用のダミーキャプションです。",
+      is_published: true,
+      created_at: Time.current - i.minutes,
+      updated_at: Time.current - i.minutes
+    )
+
+    blueprint = post.create_blueprint!(
+      user: user,
+      name: "Blueprint for Post #{i}",
+      editor_state: { "meta" => [] }
     )
   end
-  puts "Test posts created."
-else
-  puts "Posts already exist. Skip creating test posts."
+
+  # 2) トランザクションの外で添付（ここなら after_commit が即時に走り、IOが閉じられにくい）
+  post_tmp = build_png_tempfile(label: "POST #{i}")
+  post.image.attach(
+    io: post_tmp,
+    filename: "post-#{post.id}.png",
+    content_type: "image/png"
+  )
+  post_tmp.close! # attach 後に閉じる
+
+  if blueprint_has_preview_image
+    bp_tmp = build_png_tempfile(label: "BP #{i}")
+    blueprint.preview_image.attach(
+      io: bp_tmp,
+      filename: "blueprint-preview-#{blueprint.id}.png",
+      content_type: "image/png"
+    )
+    bp_tmp.close!
+  end
 end
+
+puts "Done. Published posts: #{Post.published.count}"


### PR DESCRIPTION
## 概要
Posts一覧画面にページネーションを導入した。

## 目的
- 投稿数が増えた時の一覧表示の可読性を確保

## 変更内容
- Kaminari を用いたページネーションを Posts#index に実装
- 公開投稿のみを対象に、作成日時の降順でページング
- 1ページあたり 20 件固定
- 一覧の上下に同一のページネーション UI を表示