### PR TITLE
マイページを作成

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -14,6 +14,9 @@ class PostsController < ApplicationController
   # edit/update ではフォーム表示用にBlueprintも参照
   before_action :set_blueprint, only: %i[edit update]
 
+  # 非公開投稿は所有者のみ閲覧可
+  before_action :ensure_viewable!, only: %i[show]
+
   def index
     # 公開投稿のみ + 新しい順 + 安定ソート
     @posts =
@@ -24,9 +27,16 @@ class PostsController < ApplicationController
         .per(20)
   end
 
+  def mine
+    @posts =
+      current_user.posts
+        .with_attached_image
+        .order(created_at: :desc, id: :desc)
+        .page(params[:page])
+        .per(20)
+  end
+
   def show
-    # 非公開投稿は所有者のみ閲覧可
-    ensure_viewable!
   end
 
   def new

--- a/app/views/posts/_posts_grid.html.slim
+++ b/app/views/posts/_posts_grid.html.slim
@@ -1,0 +1,36 @@
+- posts = local_assigns.fetch(:posts)
+- show_status = local_assigns.fetch(:show_status, false)
+
+- if posts.present?
+  .grid.grid-cols-1.md:grid-cols-3.lg:grid-cols-5.gap-6
+    - posts.each do |post|
+      = link_to post_path(post), class: "block group" do
+        .bg-white.rounded-xl.shadow-sm.border.border-slate-200.overflow-hidden.flex.flex-col.h-full
+          / ▼ サムネイル
+          div class="relative w-full bg-slate-100 overflow-hidden"
+            - if show_status
+              - if post.is_published?
+                .absolute.top-2.left-2.px-2.py-1.text-xs.rounded.bg-emerald-600.text-white
+                  | 公開
+              - else
+                .absolute.top-2.left-2.px-2.py-1.text-xs.rounded.bg-slate-600.text-white
+                  | 非公開
+
+            - if post.image.attached?
+              = image_tag post.image.variant(resize_to_limit: [800, 800]), class: "w-full h-auto block"
+            - else
+              = image_tag "no_image.png", class: "w-full h-auto block opacity-70"
+
+          / ▼ テキスト
+          .p-4.flex-1.flex.flex-col
+            h2.text-lg.font-semibold.text-slate-900.group-hover:text-violet-700.transition-colors
+              = post.title
+
+            p.mt-2.text-sm.text-slate-700
+              = truncate(post.caption, length: 80)
+
+            p.mt-3.text-xs.text-slate-500.mt-auto
+              | 投稿日:
+              = l post.created_at, format: :short
+- else
+  p.text-slate-500 投稿がまだありません。

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -6,32 +6,7 @@
 
     = render "pager", collection: @posts
 
-    - if @posts.present?
-      / カードのグリッドレイアウト
-      .grid.grid-cols-1.md:grid-cols-3.lg:grid-cols-5.gap-6
-        - @posts.each do |post|
-          = link_to post_path(post), class: "block group" do
-            .bg-white.rounded-xl.shadow-sm.border.border-slate-200.overflow-hidden.flex.flex-col.h-full
-              / ▼ サムネイル
-              div class="relative w-full bg-slate-100 overflow-hidden"
-                - if post.image.attached?
-                  = image_tag post.image.variant(resize_to_limit: [800, 800]), class: "w-full h-auto block"
-                - else
-                  = image_tag "no_image.png", class: "w-full h-auto block opacity-70"
-
-              / ▼ テキスト
-              .p-4.flex-1.flex.flex-col
-                h2.text-lg.font-semibold.text-slate-900.group-hover:text-violet-700.transition-colors
-                  = post.title
-
-                p.mt-2.text-sm.text-slate-700
-                  = truncate(post.caption, length: 80)
-
-                p.mt-3.text-xs.text-slate-500.mt-auto
-                  | 投稿日:
-                  = l post.created_at, format: :short
-    - else
-      p.text-slate-500 投稿がまだありません。
+    = render "posts_grid", posts: @posts
 
     = render "pager", collection: @posts
 

--- a/app/views/posts/mine.html.slim
+++ b/app/views/posts/mine.html.slim
@@ -1,0 +1,14 @@
+- breadcrumb :posts
+
+.main-container
+  .container.mx-auto.px-4.py-8
+    h1.text-2xl.font-bold.mb-4 自作物一覧
+
+    = render "pager", collection: @posts
+
+    = render "posts_grid", posts: @posts, show_status: true
+
+    = render "pager", collection: @posts
+
+    .mt-6
+      = link_to "新規投稿", new_post_path, class: "inline-block px-4 py-2 bg-violet-700 text-white rounded-md hover:bg-violet-800 text-sm"

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -25,6 +25,14 @@ header.bg-violet-700.text-white.shadow
           / ドロップダウンメニュー
           ul.absolute.right-0.mt-2.w-40.bg-white.text-slate-800.rounded-md.shadow-lg.border.border-slate-200.z-50
             li
+              = link_to "新規投稿", new_blueprint_path,
+                class: "block px-4 py-2 text-slate-700 hover:bg-slate-100"
+
+            li
+              = link_to "マイページ", mine_posts_path,
+                class: "block px-4 py-2 text-slate-700 hover:bg-slate-100"
+
+            li
               = button_to "ログアウト",
                 destroy_user_session_path,
                 method: :delete,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,10 @@ Rails.application.routes.draw do
   root "home#index"
 
   resources :posts do
+    collection do
+      get :mine
+    end
+
     member do
       delete :destroy_image
       patch  :toggle_publish


### PR DESCRIPTION
## 概要
ログインユーザーが自分の投稿（非公開を含む）を一覧で確認できるマイページを追加。

## 変更内容
- PostsControllerにcurrent_userの投稿のみを取得するmineアクションを追加
- ルーティングに/posts/mine を追加
- 投稿一覧ページのカード表示部分をパーシャル化
- ヘッダーのドロップダウンメニューに「自作物一覧」へのリンクを追加