### PR TITLE
ブックマーク機能を追加

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,0 +1,20 @@
+class BookmarksController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_post
+
+  def create
+    current_user.bookmarks.find_or_create_by!(post: @post)
+    redirect_to post_path(@post), notice: "ブックマークしました。"
+  end
+
+  def destroy
+    current_user.bookmarks.find_by!(post: @post).destroy!
+    redirect_to post_path(@post), notice: "ブックマークを解除しました。"
+  end
+
+  private
+
+  def set_post
+    @post = Post.find(params[:post_id])
+  end
+end

--- a/app/views/posts/_posts_grid.html.slim
+++ b/app/views/posts/_posts_grid.html.slim
@@ -1,5 +1,6 @@
 - posts = local_assigns.fetch(:posts)
 - show_status = local_assigns.fetch(:show_status, false)
+- bookmarked_post_ids = local_assigns.fetch(:bookmarked_post_ids, Set.new)
 
 - if posts.present?
   .grid.grid-cols-1.md:grid-cols-3.lg:grid-cols-5.gap-6
@@ -23,14 +24,27 @@
 
           / ▼ テキスト
           .p-4.flex-1.flex.flex-col
-            h2.text-lg.font-semibold.text-slate-900.group-hover:text-violet-700.transition-colors
-              = post.title
+            .flex.items-center.gap-2
+              h2.text-lg.font-semibold.text-slate-900.group-hover:text-violet-700.transition-colors
+                = post.title
 
             p.mt-2.text-sm.text-slate-700
               = truncate(post.caption, length: 80)
+            
+            .mt-3.mt-auto.flex.items-center.gap-2
+              p.text-xs.text-slate-500
+                | 投稿日:
+                = l post.created_at, format: :short
 
-            p.mt-3.text-xs.text-slate-500.mt-auto
-              | 投稿日:
-              = l post.created_at, format: :short
+              - if bookmarked_post_ids.include?(post.id)
+                .ml-auto.inline-flex.items-center.gap-2.text-xs.text-slate-600
+                  / スコープ風マーク（後で画像に差し替え可）
+                  span.relative.inline-block.w-5.h-5.rounded-full.border.border-slate-400
+                    span.absolute.left-1/2.top-0.h-full.w-px.bg-slate-400.-translate-x-1/2
+                    span.absolute.top-1/2.left-0.w-full.h-px.bg-slate-400.-translate-y-1/2
+                    span.absolute.left-1/2.top-1/2.w-1.h-1.rounded-full.bg-slate-500.-translate-x-1/2.-translate-y-1/2
+                  span.font-medium
+                    | Marked
+
 - else
   p.text-slate-500 投稿がまだありません。

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -4,12 +4,15 @@
   .container.mx-auto.px-4.py-8
     h1.text-2xl.font-bold.mb-4 投稿一覧
 
-    = render "pager", collection: @posts
-
-    = render "posts_grid", posts: @posts
-
-    = render "pager", collection: @posts
-
     - if user_signed_in?
-      .mt-6
-        = link_to "新規投稿", new_post_path, class: "inline-block px-4 py-2 bg-violet-700 text-white rounded-md hover:bg-violet-800 text-sm"
+      .mb-4
+        - if params[:bookmarked] == "1"
+          = link_to "絞り込み解除", posts_path, class: "inline-flex items-center px-3 py-1 rounded border border-slate-300 bg-white text-slate-700 hover:bg-slate-50 text-xs"
+        - else
+          = link_to "ブックマークのみ表示", posts_path(bookmarked: 1), class: "inline-flex items-center px-3 py-1 rounded bg-violet-600 text-white hover:bg-violet-700 text-xs"
+
+    = render "pager", collection: @posts
+
+    = render "posts_grid", posts: @posts, bookmarked_post_ids: @bookmarked_post_ids
+
+    = render "pager", collection: @posts

--- a/app/views/posts/mine.html.slim
+++ b/app/views/posts/mine.html.slim
@@ -9,6 +9,3 @@
     = render "posts_grid", posts: @posts, show_status: true
 
     = render "pager", collection: @posts
-
-    .mt-6
-      = link_to "新規投稿", new_post_path, class: "inline-block px-4 py-2 bg-violet-700 text-white rounded-md hover:bg-violet-800 text-sm"

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -63,7 +63,18 @@
             / 操作ボタン群
             .mt-4.flex.flex-wrap.gap-3
               - if user_signed_in?
-                / ★ ブックマークボタンなど今後ここに追加
+                - if @bookmarked
+                  = button_to "ブックマーク解除",
+                              post_bookmark_path(@post),
+                              method: :delete,
+                              data: { turbo_confirm: "ブックマークを解除しますか？" },
+                              class: "inline-flex.items-center.px-3.py-2.rounded-md.border.border-slate-300.text-xs.text-slate-700.bg-white.hover:bg-slate-50"
+                - else
+                  = button_to "ブックマーク",
+                              post_bookmark_path(@post),
+                              method: :post,
+                              class: "inline-flex.items-center.px-3.py-2.rounded-md.bg-violet-600.text-xs.text-white.hover:bg-violet-700"
+
                 - if @post.user == current_user
                   = link_to "編集",
                             edit_post_path(@post),
@@ -74,6 +85,10 @@
                               method: :delete,
                               data: { turbo_confirm: "この投稿を削除しますか？（元に戻せません）" },
                               class: "inline-flex.items-center.px-3.py-2.rounded-md.border.border-red-300.text-xs.text-red-700.bg-red-50.hover:bg-red-100"
+              - else
+                p.text-xs.text-slate-500
+                  | ブックマークにはログインが必要です。
+                  = link_to "ログイン", new_user_session_path, class: "ml-1.text-violet-700.hover:underline"
 
           / ---- 下：コメントエリア（右下の小ウィンドウでスクロール）----
           .mt-2

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
     end
 
     resources :comments, only: %i[create destroy]
+    resource :bookmark, only: %i[create destroy]
   end
 
   resources :blueprints, only: %i[new create edit update show] do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,106 +1,43 @@
 # db/seeds.rb
-require "tempfile"
-require "base64"
 
-DESIRED_POSTS = 45
-TEST_EMAIL = "test@example.com"
+POSTS_PER_USER = 5
 
-# 1x1 PNG (透明) fallback
-PNG_1X1_BASE64 =
-  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6X8n9kAAAAASUVORK5CYII="
+puts "== Seeding posts for existing users =="
 
-def build_png_tempfile(label:)
-  tmp = Tempfile.new([ "seed-post-", ".png" ])
-  tmp.binmode
+users = User.limit(3).to_a
 
-  # MiniMagick が使えるなら、少し大きめの画像を生成（一覧で見やすい）
-  begin
-    require "mini_magick"
-
-    MiniMagick::Tool::Convert.new do |convert|
-      convert.size "800x600"
-      convert.xc "#f1f5f9"            # slate-100 相当の背景
-      convert.gravity "center"
-      convert.pointsize "42"
-      convert.fill "#0f172a"          # slate-900 相当
-      convert.draw "text 0,0 '#{label}'"
-      convert << tmp.path
-    end
-  rescue LoadError, StandardError
-    # 画像生成に失敗しても seeds が落ちないよう、最小PNGで代替
-    tmp.write(Base64.decode64(PNG_1X1_BASE64))
-  end
-
-  tmp.rewind
-  tmp
-end
-
-# テストユーザー（既存ならそれを使用）
-user = User.find_or_create_by!(email: TEST_EMAIL) do |u|
-  u.name = "テストユーザー"
-  u.password = "password"
-  u.password_confirmation = "password"
-end
-puts "Test user: #{user.email} (id=#{user.id})"
-
-current_count = Post.published.count
-to_create = [ DESIRED_POSTS - current_count, 0 ].max
-
-if to_create.zero?
-  puts "Published posts already exist (#{current_count}). Skip creating posts."
+if users.empty?
+  puts "No users found. Please create users first."
   exit
 end
 
-# Blueprint が preview_image を持つか（環境差で落とさない）
-blueprint_has_preview_image =
-  Blueprint.respond_to?(:reflect_on_attachment) &&
-  Blueprint.reflect_on_attachment(:preview_image).present?
+users.each_with_index do |user, user_index|
+  puts "User: #{user.email} (id=#{user.id})"
 
-puts "Creating #{to_create} published posts (current published: #{current_count} / desired: #{DESIRED_POSTS})..."
-puts "Blueprint preview_image attach: #{blueprint_has_preview_image ? 'enabled' : 'skipped'}"
+  existing_count = user.posts.count
+  to_create = [ POSTS_PER_USER - existing_count, 0 ].max
 
-to_create.times do |n|
-  i = current_count + n + 1
+  if to_create.zero?
+    puts "  Posts already exist (#{existing_count}). Skip."
+    next
+  end
 
-  post = nil
-  blueprint = nil
+  to_create.times do |i|
+    index = existing_count + i + 1
 
-  # 1) まず DB だけ作る（ここでは添付しない）
-  ActiveRecord::Base.transaction do
-    post = Post.create!(
+    Post.create!(
       user: user,
-      title: "テスト投稿 #{i}",
-      caption: "これはテスト投稿 #{i} です。ページネーション表示確認用のダミーキャプションです。",
-      is_published: true,
-      created_at: Time.current - i.minutes,
-      updated_at: Time.current - i.minutes
-    )
-
-    blueprint = post.create_blueprint!(
-      user: user,
-      name: "Blueprint for Post #{i}",
-      editor_state: { "meta" => [] }
+      title: "Seed Post #{user_index + 1}-#{index}",
+      caption: "ユーザー#{user.name}によるテスト投稿 #{index} です。",
+      is_published: index.odd?, # 奇数だけ公開（動作確認用）
+      created_at: Time.current - (user_index * 10 + index).minutes,
+      updated_at: Time.current - (user_index * 10 + index).minutes
     )
   end
 
-  # 2) トランザクションの外で添付（ここなら after_commit が即時に走り、IOが閉じられにくい）
-  post_tmp = build_png_tempfile(label: "POST #{i}")
-  post.image.attach(
-    io: post_tmp,
-    filename: "post-#{post.id}.png",
-    content_type: "image/png"
-  )
-  post_tmp.close! # attach 後に閉じる
-
-  if blueprint_has_preview_image
-    bp_tmp = build_png_tempfile(label: "BP #{i}")
-    blueprint.preview_image.attach(
-      io: bp_tmp,
-      filename: "blueprint-preview-#{blueprint.id}.png",
-      content_type: "image/png"
-    )
-    bp_tmp.close!
-  end
+  puts "  Created #{to_create} posts."
 end
 
-puts "Done. Published posts: #{Post.published.count}"
+puts "== Done =="
+puts "Total posts: #{Post.count}"
+puts "Published posts: #{Post.published.count}"

--- a/test/controllers/bookmarks_controller_test.rb
+++ b/test/controllers/bookmarks_controller_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class BookmarksControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @post = posts(:published_one)
+    @user = users(:one)
+  end
+
+  test "should redirect create when not signed in" do
+    assert_no_difference("Bookmark.count") do
+      post post_bookmark_url(@post)
+    end
+    assert_response :redirect
+  end
+
+  test "should create bookmark when signed in" do
+    sign_in @user
+    assert_difference("Bookmark.count", 1) do
+      post post_bookmark_url(@post)
+    end
+    assert_redirected_to post_url(@post)
+  end
+
+  test "should not create duplicate bookmark" do
+    sign_in @user
+    Bookmark.create!(user: @user, post: @post)
+
+    assert_no_difference("Bookmark.count") do
+      post post_bookmark_url(@post)
+    end
+    assert_redirected_to post_url(@post)
+  end
+
+  test "should destroy bookmark when signed in" do
+    sign_in @user
+    Bookmark.create!(user: @user, post: @post)
+
+    assert_difference("Bookmark.count", -1) do
+      delete post_bookmark_url(@post)
+    end
+    assert_redirected_to post_url(@post)
+  end
+
+  test "should redirect destroy when not signed in" do
+    Bookmark.create!(user: @user, post: @post)
+
+    assert_no_difference("Bookmark.count") do
+      delete post_bookmark_url(@post)
+    end
+    assert_response :redirect
+  end
+end

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -3,71 +3,85 @@ require "test_helper"
 class PostsControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  # Index / Show
+  setup do
+    @published_post = posts(:published_one)
+    @unpublished_post = posts(:one)
+
+    @owner = users(:one)
+    @other = users(:two)
+  end
+
+  # Index
 
   test "should get index" do
     get posts_url
     assert_response :success
   end
 
-  test "should get show when post is published" do
-    post = posts(:published_one)
+  test "should filter bookmarked posts when bookmarked=1 and signed in" do
+    bookmarked_post = posts(:published_one)
+    not_bookmarked_post = posts(:published_two)
 
-    get post_url(post)
+    Bookmark.create!(user: @owner, post: bookmarked_post)
+    sign_in @owner
+
+    get posts_url(bookmarked: "1")
+    assert_response :success
+    assert_includes @response.body, bookmarked_post.title
+    refute_includes @response.body, not_bookmarked_post.title
+  end
+
+
+  # Show (authorization)
+
+  test "should get show when post is published" do
+    get post_url(@published_post)
     assert_response :success
   end
 
   test "should get 404 when post is unpublished and user is not signed in" do
-    post = posts(:one)
-
-    get post_url(post)
+    get post_url(@unpublished_post)
     assert_response :not_found
   end
 
   test "should get 404 when post is unpublished and user is not the owner" do
-    post = posts(:one)
-
-    sign_in users(:two)
-    get post_url(post)
+    sign_in @other
+    get post_url(@unpublished_post)
     assert_response :not_found
   end
 
   test "should get show when post is unpublished and user is the owner" do
-    post = posts(:one)
-
-    sign_in users(:one)
-    get post_url(post)
+    sign_in @owner
+    get post_url(@unpublished_post)
     assert_response :success
   end
 
   # Publish / Unpublish
 
   test "owner can toggle publish" do
-    post = posts(:one)
+    sign_in @owner
 
-    sign_in users(:one)
-    patch toggle_publish_post_url(post)
+    patch toggle_publish_post_url(@unpublished_post)
+    assert_redirected_to post_url(@unpublished_post)
 
-    assert_redirected_to post_url(post)
-    post.reload
-    assert_equal true, post.is_published
+    @unpublished_post.reload
+    assert_equal true, @unpublished_post.is_published
   end
 
   test "non-owner cannot toggle publish" do
-    post = posts(:one)
+    sign_in @other
 
-    sign_in users(:two)
-    patch toggle_publish_post_url(post)
-
+    patch toggle_publish_post_url(@unpublished_post)
     assert_redirected_to posts_url
-    post.reload
-    assert_equal false, post.is_published
+
+    @unpublished_post.reload
+    assert_equal false, @unpublished_post.is_published
   end
 
-  # New / Edit
+  # New / Edit (login required)
 
   test "should get new" do
-    sign_in users(:one)
+    sign_in @owner
 
     blueprint = blueprints(:draft_one)
     get new_post_url(blueprint_id: blueprint.id)
@@ -76,16 +90,16 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get edit" do
-    sign_in users(:one)
-    post = posts(:one)
-    get edit_post_url(post)
+    sign_in @owner
+
+    get edit_post_url(@unpublished_post)
     assert_response :success
   end
 
   # Guards
 
   test "should redirect new with already posted blueprint" do
-    sign_in users(:one)
+    sign_in @owner
 
     blueprint = blueprints(:one) # post: one が付いている
     get new_post_url(blueprint_id: blueprint.id)

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -37,3 +37,9 @@ published_one:
   title: Published Post
   caption: Published
   is_published: true
+
+published_two:
+  user: two
+  title: Published Post 2
+  caption: Published 2
+  is_published: true


### PR DESCRIPTION
## 概要

Post に対するブックマーク機能を実装した。
* 詳細ページで登録／解除
* 一覧ページで絞り込み表示

## 仕様

* Bookmarkモデルにはuser_id + post_idのユニーク制約を設定（二重登録を防ぐ）
* ブックマーク操作はログインユーザーのみ許可
* 自分の投稿もブックマーク可能（現段階では）

## 変更内容

### Post詳細ページ

* ブックマーク登録／解除ボタンを追加
* ログインユーザーのみ操作可能とする認可制御を実装

### Post一覧表示

* ブックマーク済みのPostを一覧ページで絞り込めるようにした
* ページ表示時にブックマーク済みPostIDを一括取得（N+1クエリ問題）
* 各Postのカードパネルにブックマーク済み状態を示す表示を追加

## 動作確認

* ブラウザ上で以下を確認

  * ブックマーク登録／解除
  * Post一覧でのブックマーク済み表示
  * 絞り込みON/OFFの切り替え